### PR TITLE
Update colima disk size and add auto docker prune launchd daemon

### DIFF
--- a/machines/mac-mini.nix
+++ b/machines/mac-mini.nix
@@ -35,5 +35,19 @@
     sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
   '';
 
+  # Prune docker everyday at 00h
+  launchd.daemons.prune-docker = {
+    command = "${pkgs.docker}/bin/docker system prune -f";
+    serviceConfig = {
+      StartCalendarInterval = [
+        {
+          Hour = 0;
+          Minute = 0;
+        }
+      ];
+    };
+  };
+
+
   nixpkgs.hostPlatform = "aarch64-darwin";
 }

--- a/machines/mac-mini.nix
+++ b/machines/mac-mini.nix
@@ -31,7 +31,7 @@
 
   system.activationScripts.postUserActivation.text = ''
     echo "Enabling docker..."
-    ${pkgs.colima}/bin/colima start --cpu 8 --memory 6 --mount /private/var/run/github-runners
+    ${pkgs.colima}/bin/colima start --cpu 8 --memory 6 --disk 80 --mount /private/var/run/github-runners
     sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
   '';
 


### PR DESCRIPTION
# Description

Sometimes Android CI E2E tests fail because there is no space left on the Colima VM.
This PR increases the Colima disk size and adds a launchd daemon to clean the Colima disk every day at 00h.